### PR TITLE
clarify plugin creation information

### DIFF
--- a/articles/dev_guide/plugin_tutorial/2_plugin_start.md
+++ b/articles/dev_guide/plugin_tutorial/2_plugin_start.md
@@ -38,7 +38,7 @@ To create a project in the folder, do the following depending on the game type y
     > As a general rule, you can always target `net35`.
     > However, the lower TFM, the less standard libraries and methods are available to you.
 
-2. Determine *Unity version* of your game (in format `X.Y.Z` where `X`, `Y` and `Z` are integers. e.g. (`2020.3.24`).
+2. Determine *Unity version* of your game (in format `X.Y.Z` where `X`, `Y` and `Z` are integers. e.g. `2020.3.24`).
    
    There are a few ways of doing it:
 

--- a/articles/dev_guide/plugin_tutorial/2_plugin_start.md
+++ b/articles/dev_guide/plugin_tutorial/2_plugin_start.md
@@ -31,10 +31,10 @@ To create a project in the folder, do the following depending on the game type y
     
     You can follow this general-purpose choice process:
 
-    * If the game has `netstandard.dll` in `<Game Name>_Data/Managed` folder, your TFM is `netstandard2.0`, or if you run into reference errors target `net472`
-    **OR**
-    * If the game's `mscorlib.dll` file version (right click the file -> `Properties` -> `Details`) is at least `4.0.0.0` or newer, your TFM is `net46`
-    **OR**
+    * If the game has `netstandard.dll` in `<Game Name>_Data/Managed` folder, your TFM is `netstandard2.0`, or if you run into reference errors target `net472`  
+    **OR**  
+    * If the game's `mscorlib.dll` file version (right click the file -> `Properties` -> `Details`) is at least `4.0.0.0` or newer, your TFM is `net46`  
+    **OR**  
     * In any other case, or if you are unsure/unable to verify using the methods above, your TFM is `net35`
 
     > [!NOTE]

--- a/articles/dev_guide/plugin_tutorial/2_plugin_start.md
+++ b/articles/dev_guide/plugin_tutorial/2_plugin_start.md
@@ -50,6 +50,7 @@ To create a project in the folder, do the following depending on the game type y
 
    ```bash
    dotnet new bep6plugin_unitymono -n MyFirstPlugin -T <TFM> -U <Unity>
+   dotnet restore MyFirstPlugin
    ```
 
    where 
@@ -63,6 +64,7 @@ In the command line prompt, run
 
 ```bash
 dotnet new bep6plugin_il2cpp -n MyFirstPlugin
+dotnet restore MyFirstPlugin
 ```
 
 # [.NET Framework](#tab/tabid-netfw)
@@ -71,6 +73,7 @@ In the command line prompt, run
 
 ```bash
 dotnet new bep6plugin_netfx -n MyFirstPlugin
+dotnet restore MyFirstPlugin
 ```
 
 ***

--- a/articles/dev_guide/plugin_tutorial/2_plugin_start.md
+++ b/articles/dev_guide/plugin_tutorial/2_plugin_start.md
@@ -31,7 +31,10 @@ To create a project in the folder, do the following depending on the game type y
     
     You can follow this general-purpose choice process:
 
-    * If the has `netstandard.dll` in `<Game Name>_Data/Managed` folder or the `mscorlib.dll` file version (right click the file -> `Properties` -> `Details`) is at least `4.0.0.0` or newer, your TFM is `net48`
+    * If the game has `netstandard.dll` in `<Game Name>_Data/Managed` folder, your TFM is `netstandard2.0`, or if you run into reference errors target `net472`
+    **OR**
+    * If the game's `mscorlib.dll` file version (right click the file -> `Properties` -> `Details`) is at least `4.0.0.0` or newer, your TFM is `net46`
+    **OR**
     * In any other case, or if you are unsure/unable to verify using the methods above, your TFM is `net35`
 
     > [!NOTE]

--- a/articles/dev_guide/plugin_tutorial/2_plugin_start.md
+++ b/articles/dev_guide/plugin_tutorial/2_plugin_start.md
@@ -31,15 +31,14 @@ To create a project in the folder, do the following depending on the game type y
     
     You can follow this general-purpose choice process:
 
-    * If the game has `netstandard.dll` in `<Game Name>_Data/Managed` folder, your TFM is `netstandard2.0`
-    * If the game's `mscorlib.dll` file version (right click the file -> `Properties` -> `Details`) is at least `4.0.0.0` or newer, your TFM is `net46`
+    * If the has `netstandard.dll` in `<Game Name>_Data/Managed` folder or the `mscorlib.dll` file version (right click the file -> `Properties` -> `Details`) is at least `4.0.0.0` or newer, your TFM is `net48`
     * In any other case, or if you are unsure/unable to verify using the methods above, your TFM is `net35`
 
     > [!NOTE]
     > As a general rule, you can always target `net35`.
     > However, the lower TFM, the less standard libraries and methods are available to you.
 
-2. Determine *Unity version* of your game (in format `X.Y.Z` where `X`, `Y` and `Z` are integers).
+2. Determine *Unity version* of your game (in format `X.Y.Z` where `X`, `Y` and `Z` are integers. e.g. (`2020.3.24`).
    
    There are a few ways of doing it:
 

--- a/articles/dev_guide/plugin_tutorial/2_plugin_start.md
+++ b/articles/dev_guide/plugin_tutorial/2_plugin_start.md
@@ -31,7 +31,7 @@ To create a project in the folder, do the following depending on the game type y
     
     You can follow this general-purpose choice process:
 
-    * If the game has `netstandard.dll` in `<Game Name>_Data/Managed` folder, your TFM is `netstandard2.0`, or if you run into reference errors target `net472`  
+    * If the game has `netstandard.dll` in `<Game Name>_Data/Managed` folder, your TFM is `netstandard2.0`. If you run into reference errors, target `net472`.  
     **OR**  
     * If the game's `mscorlib.dll` file version (right click the file -> `Properties` -> `Details`) is at least `4.0.0.0` or newer, your TFM is `net46`  
     **OR**  


### PR DESCRIPTION
- Simply suggest .net framework 4.8 if the game supports .net framework 4. I don't think there's any downside to just recommending this?

According to the Microsoft docs (https://docs.microsoft.com/en-us/dotnet/standard/net-standard):
"The versions listed here represent the rules that NuGet uses to determine whether a given .NET Standard library is applicable. While NuGet considers .NET Framework 4.6.1 as supporting .NET Standard 1.5 through 2.0, there are several issues with consuming .NET Standard libraries that were built for those versions from .NET Framework 4.6.1 projects. For .NET Framework projects that need to use such libraries, we recommend that you upgrade the project to target .NET Framework 4.7.2 or higher."

I'm not 100% sure about games that might only support net46? Is this even a thing/would it be problematic if they used plugins that targeted net48? Either way that would be a much smaller number of users so easier to deal with questions about that if it comes up.

- Added example to the unity version instructions to avoid confusion there as well