### PR TITLE
Fix typo in index.md

### DIFF
--- a/articles/advanced/debug/index.md
+++ b/articles/advanced/debug/index.md
@@ -5,12 +5,12 @@ title: Debugging plugins
 # Debugging plugins
 
 Debugging BepInEx plugins can pose a challenge depending on the game and the plugin.  
-Currently there are two ways to debug plugins and Unity games
+Currently there are two ways to debug plugins and Unity games:
 
 1. Using dnSpy and its debug builds of the Mono runtime
 2. Converting the game to debug build and using Visual Studio Tools for Unity (or Rider's Unity extension) 
 
-Depending on your needs an tooling, you might need to use different approaches 
+Depending on your needs and tooling, you might need to use different approaches 
 to debugging Unity games. If you are unsure which way to use, we suggest 
 first trying out debugging with dnSpy.
 


### PR DESCRIPTION
Just a small typo fix and added a colon before the list of debugging approaches. Merry Christmas and happy New Year!