### PR TITLE
Change -i to install within dotnet new install

### DIFF
--- a/articles/dev_guide/plugin_tutorial/1_setup.md
+++ b/articles/dev_guide/plugin_tutorial/1_setup.md
@@ -91,7 +91,7 @@ We will be using them to make our plugins.
 To install the template, run the following command:
 
 ```bash
-dotnet new -i BepInEx.Templates::2.0.0-be.2 --nuget-source https://nuget.bepinex.dev/v3/index.json
+dotnet new install BepInEx.Templates::2.0.0-be.2 --nuget-source https://nuget.bepinex.dev/v3/index.json
 ```
 
 If the install is successful, you should see a listing of all .NET project templates.


### PR DESCRIPTION
Use of 'dotnet new --install' is deprecated. This can be confirmed when you run dotnet new -i in the console