### PR TITLE
update instructions to point to be.4 template

### DIFF
--- a/articles/dev_guide/plugin_tutorial/1_setup.md
+++ b/articles/dev_guide/plugin_tutorial/1_setup.md
@@ -91,7 +91,7 @@ We will be using them to make our plugins.
 To install the template, run the following command:
 
 ```bash
-dotnet new install BepInEx.Templates::2.0.0-be.3 --nuget-source https://nuget.bepinex.dev/v3/index.json
+dotnet new install BepInEx.Templates::2.0.0-be.4 --nuget-source https://nuget.bepinex.dev/v3/index.json
 ```
 
 If the install is successful, you should see a listing of all .NET project templates.


### PR DESCRIPTION
This can be merged after https://github.com/BepInEx/BepInEx.Templates/pull/16 is merged and a new template release is published