### PR TITLE
Update install templates command

### DIFF
--- a/articles/dev_guide/plugin_tutorial/1_setup.md
+++ b/articles/dev_guide/plugin_tutorial/1_setup.md
@@ -91,7 +91,7 @@ We will be using them to make our plugins.
 To install the template, run the following command:
 
 ```bash
-dotnet new install BepInEx.Templates::2.0.0-be.4 --nuget-source https://nuget.bepinex.dev/v3/index.json
+dotnet new --install BepInEx.Templates::2.0.0-be.4 --nuget-source https://nuget.bepinex.dev/v3/index.json
 ```
 
 If the install is successful, you should see a listing of all .NET project templates.


### PR DESCRIPTION
There seems to be a typo in the command for installing plugin templates, it should have `--install` flag instead of `install`
![image](https://github.com/BepInEx/bepinex-docs/assets/77974051/d60db4ca-5e8b-42c9-8878-8ddc2114b2ed)
