### PR TITLE
Update index.md to use LogOutput.log

### DIFF
--- a/articles/user_guide/installation/index.md
+++ b/articles/user_guide/installation/index.md
@@ -70,7 +70,7 @@ Currently, BepInEx can be installed manually.
 
     # [Windows](#tab/tabid-win)
     Simply run the game executable. This should generate BepInEx configuration 
-    file into `BepInEx/config` folder and an initial log file `BepInEx/LogOutput.txt`.
+    file into `BepInEx/config` folder and an initial log file `BepInEx/LogOutput.log`.
 
     # [Linux/macOS](#tab/tabid-nix)
     > [!NOTE]

--- a/articles/user_guide/installation/index.md
+++ b/articles/user_guide/installation/index.md
@@ -97,7 +97,7 @@ Currently, BepInEx can be installed manually.
     ./run_bepinex.sh
     ```
     This should generate BepInEx configuration 
-    file into `BepInEx/config` folder and an initial log file `BepInEx/LogOutput.txt`.
+    file into `BepInEx/config` folder and an initial log file `BepInEx/LogOutput.log`.
     ***
     
 4. Configure BepInEx to suit your needs. 


### PR DESCRIPTION
LogOutput.log, rather than LogOutput.txt, seems to be the name of the log file produced by the latest release.

There is a similar line under the Linux instructions that I left alone, but maybe that needs to be changed as well.