### PR TITLE
Update 2_plugin_start.md

### DIFF
--- a/articles/dev_guide/plugin_tutorial/2_plugin_start.md
+++ b/articles/dev_guide/plugin_tutorial/2_plugin_start.md
@@ -31,7 +31,7 @@ To create a project in the folder, do the following depending on the game type y
     
     You can follow this general-purpose choice process:
 
-    * If the game has `netstandard.dll` in `<Game Name>_Data/Managed` folder, your TFM is `netstandard2.0`. If you run into reference errors, target `net472`.  
+    * If the game has `netstandard.dll` in `<Game Name>_Data/Managed` folder, your TFM is `netstandard2.0` (for Unity 2021.1.x or older) or `netstandard2.1` (for Unity 2021.2 or newer). If you run into reference errors, target `net472`.  
     **OR**  
     * If the game's `mscorlib.dll` file version (right click the file -> `Properties` -> `Details`, `exiftool mscorlib.dll | grep "File Version"` on Linux) is at least `4.0.0.0` or newer, your TFM is `net46`  
     **OR**  


### PR DESCRIPTION
Changed .net standard version from 2.0 to 2.1 for games using unity 2021.2 or newer.

For reference see .NET profile support changing between version 2021.1 and 2021.2 in the official unity docs:
https://docs.unity3d.com/2021.1/Documentation/Manual/dotnetProfileSupport.html
https://docs.unity3d.com/2021.2/Documentation/Manual/dotnetProfileSupport.html